### PR TITLE
Add dependabot to update GHA

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,8 +1,10 @@
 ---
 name: Integration
 
-"on":
+on:
   push:
+    branches:
+      - main
   pull_request:
 
 permissions:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,10 @@
 ---
 name: Lint
 
-"on":
+on:
   push:
+    branches:
+      - main
   pull_request:
 
 permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,8 @@ name: Test
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 permissions:


### PR DESCRIPTION
- Add `dependabot` config to bump GH actions

    So that these stay up-to-date

- Avoid duplicate actions running on PRs

    That is, avoid a push to a PR trigger both `push` and `pull_request`
    conditions.