### PR TITLE
Fix permission issues on labeler action

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,6 +9,9 @@ name: Labeler
 jobs:
   labeler:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: Check out the repository
         uses: actions/checkout@v4


### PR DESCRIPTION
This was failing with errors like

    Error: Cannot create "ci" label: Resource not accessible by integration

Resolve this by giving it permissions as documented[1]

Link: https://github.com/crazy-max/ghaction-github-labeler/blob/01de93bf839107571474d69baed8ad90ec996dcc/README.md#workflow [1]