### PR TITLE
Rely on `pip` version installed with with `setup-python`

### DIFF
--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -1,2 +1,0 @@
-pip==23.2
-virtualenv==20.17.1

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,14 +33,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Upgrade pip
-        run: |
-          pip install --constraint=.github/workflows/constraints.txt pip
-          pip --version
-
       - name: Install Poetry
         run: |
-          pipx install --pip-args=--constraint=.github/workflows/poetry-constraints.txt poetry
+          pip install --constraint=.github/workflows/poetry-constraints.txt poetry
           poetry --version
 
       - name: Install dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,11 +33,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Upgrade pip
-        run: |
-          pip install --constraint=.github/workflows/constraints.txt pip
-          pip --version
-
       - name: Install Poetry
         run: |
           pip install --constraint=.github/workflows/poetry-constraints.txt poetry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,6 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Upgrade pip
-        run: |
-          pip install --constraint=.github/workflows/constraints.txt pip
-          pip --version
-
       - name: Install Poetry
         run: |
           pip install --constraint=.github/workflows/poetry-constraints.txt poetry

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,11 +59,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Upgrade pip
-        run: |
-          pip install --constraint=.github/workflows/constraints.txt pip
-          pip --version
-
       - name: Install Poetry
         run: |
           pip install --constraint=.github/workflows/poetry-constraints.txt poetry


### PR DESCRIPTION
Rather than keeping track of some version ourselves. We only use pip to install `poetry`, so it should be fine to just rely on this